### PR TITLE
Option to turn off global status integration

### DIFF
--- a/skype-wrapper/data/schemas/apps.skype-wrapper.gschema.xml
+++ b/skype-wrapper/data/schemas/apps.skype-wrapper.gschema.xml
@@ -71,5 +71,10 @@
       <summary>CPU Limit (experimental)</summary>
       <description>Requires Restart. This is the CPU limiter for indicator-skype to ensure that it doesn't consume too much CPU time. Increase this if the performance is bad</description>
     </key>
+    <key type="b" name="use-global-status">
+      <default>true</default>
+      <summary>Use global status</summary>
+      <description>Set Skype status from Messaging Menu (true) or independently (false).</description>
+    </key>
   </schema>
 </schemalist>

--- a/skype-wrapper/debian/skype-wrapper/usr/share/glib-2.0/schemas/apps.skype-wrapper.gschema.xml
+++ b/skype-wrapper/debian/skype-wrapper/usr/share/glib-2.0/schemas/apps.skype-wrapper.gschema.xml
@@ -71,5 +71,10 @@
       <summary>CPU Limit (experimental)</summary>
       <description>Requires Restart. This is the CPU limiter for indicator-skype to ensure that it doesn't consume too much CPU time. Increase this if the performance is bad</description>
     </key>
+    <key type="b" name="use-global-status">
+      <default>true</default>
+      <summary>Use global status</summary>
+      <description>Set Skype status from Messaging Menu (true) or independently (false).</description>
+    </key>
   </schema>
 </schemalist>

--- a/skype-wrapper/debian/skype-wrapper/usr/share/skype-wrapper/indicator-applet-skype.py
+++ b/skype-wrapper/debian/skype-wrapper/usr/share/skype-wrapper/indicator-applet-skype.py
@@ -707,7 +707,7 @@ class SkypeBehaviour:
         log("Couldn't open chat window ("+str(e)+")", WARNING)
     
   def setPresence(self, presence):
-    if not helpers.isInstalled('telepathy-mission-control-5'):
+    if not helpers.isInstalled('telepathy-mission-control-5') or 'mission-control' not in commands.getoutput('ps -A | grep mission-control' ) or not settings.get_use_global_status():
         return
         
     account_manager = bus.get_object('org.freedesktop.Telepathy.AccountManager',
@@ -730,7 +730,7 @@ class SkypeBehaviour:
             dbus_interface='org.freedesktop.DBus.Properties')
   
   def getPresence(self) :
-    if not helpers.isInstalled('telepathy-mission-control-5'):
+    if not helpers.isInstalled('telepathy-mission-control-5') or 'mission-control' not in commands.getoutput('ps -A | grep mission-control' ) or not settings.get_use_global_status():
         return None
         
     account_manager = bus.get_object('org.freedesktop.Telepathy.AccountManager',

--- a/skype-wrapper/debian/skype-wrapper/usr/share/skype-wrapper/settings.py
+++ b/skype-wrapper/debian/skype-wrapper/usr/share/skype-wrapper/settings.py
@@ -49,3 +49,6 @@ def get_debug_level():
     
 def get_cpu_limit():
     return float(settings.get_string("cpu-percentage-limit"))
+
+def get_use_global_status():
+    return settings.get_boolean("use-global-status")

--- a/skype-wrapper/src/indicator-applet-skype.py
+++ b/skype-wrapper/src/indicator-applet-skype.py
@@ -787,7 +787,7 @@ class SkypeBehaviour:
         log("Couldn't open chat window ("+str(e)+")", WARNING)
     
   def setPresence(self, presence):
-    if not helpers.isInstalled('telepathy-mission-control-5') or 'mission-control' not in commands.getoutput('ps -A | grep mission-control' ):
+    if not helpers.isInstalled('telepathy-mission-control-5') or 'mission-control' not in commands.getoutput('ps -A | grep mission-control' ) or not settings.get_use_global_status():
         return
         
     account_manager = bus.get_object('org.freedesktop.Telepathy.AccountManager',
@@ -811,7 +811,7 @@ class SkypeBehaviour:
             dbus_interface='org.freedesktop.DBus.Properties')
   
   def getPresence(self) :
-    if not helpers.isInstalled('telepathy-mission-control-5') or 'mission-control' not in commands.getoutput('ps -A | grep mission-control' ):
+    if not helpers.isInstalled('telepathy-mission-control-5') or 'mission-control' not in commands.getoutput('ps -A | grep mission-control' ) or not settings.get_use_global_status():
         return None
         
     account_manager = bus.get_object('org.freedesktop.Telepathy.AccountManager',

--- a/skype-wrapper/src/settings.py
+++ b/skype-wrapper/src/settings.py
@@ -49,3 +49,6 @@ def get_debug_level():
     
 def get_cpu_limit():
     return float(settings.get_string("cpu-percentage-limit"))
+
+def get_use_global_status():
+    return settings.get_boolean("use-global-status")


### PR DESCRIPTION
This adds `use-global-status` to settings, which allows Skype status to be set independently from Telepathy (see issue #42). It defaults to `true`, thus preserving current behavior.
